### PR TITLE
fixes 2 null parameter checks

### DIFF
--- a/R/MultiStrainPartialImmunity.R
+++ b/R/MultiStrainPartialImmunity.R
@@ -29,10 +29,10 @@ MultiStrainPartialImmunity <- function(pars = NULL, init = NULL, time = NULL, ..
   if (is.null(pars)) {
     stop("undefined 'pars'")
   }
-  if (is.null(pars)) {
+  if (is.null(init)) {
     stop("undefined 'inits'")
   }
-  if (is.null(pars)) {
+  if (is.null(time)) {
     stop("undefined 'time'")
   }
   function1 <- function(pars = NULL, init = NULL, time = NULL) {


### PR DESCRIPTION
In original code there are 3 checks whose purpose is to check for missing (NULL) input
parameters in to method "MultiStrainPartialImmunity"
There were 2 bugs. This pull request (PR) fixes those bugs. 
The fix simply contains the correct parameter names.
